### PR TITLE
Fixed an unclosed double quote

### DIFF
--- a/sonar.info
+++ b/sonar.info
@@ -3,7 +3,7 @@ description = Automatic SASS compilations.
 core = 7.x
 package = User interface
 
-version = "7.x-1.1
+version = "7.x-1.1"
 core = "7.x"
 
 ; Our plugins interfaces and abstract implementations.


### PR DESCRIPTION
The version in Drupal admin shows as "7.x-1.1 because the quote is opened and not closed.
